### PR TITLE
[CI] Archive test results on `results` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: llvm/circt
-          fetch-depth: 1
           submodules: recursive
           path: circt
 
@@ -70,9 +69,12 @@ jobs:
           ninja -C circt/build circt-verilog
           echo "$PWD/circt/build/bin" >> "$GITHUB_PATH"
 
-      # Fetch all submodules needed to run the tests.
-      - name: Update submodules for tests
-        run: utils/update-all.sh
+      # Fetch all submodules needed to run the tests. Also clear any temporary
+      # directories that happen to already exist.
+      - name: Prepare for tests
+        run: |
+          utils/update-all.sh
+          rm -rf build results
 
       # Run individual tests.
       - name: Compile Snitch
@@ -85,4 +87,47 @@ jobs:
 
       # Display some results.
       - name: Results for sv-tests
-        run: cat ext/sv-tests/out/errors.txt
+        run: cat results/sv-tests/errors.txt
+
+      # Upload the results as an artifact.
+      - name: Upload results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: results
+          compression-level: 9
+          path: results
+
+      # Archive the `results` directory on the `results` branch.
+      - name: Checkout results branch
+        uses: actions/checkout@v5
+        with:
+          ref: results
+          path: results-branch
+
+      - name: Archive results
+        run: |
+          # Copy the results to the target location.
+          COMMIT=$(git -C circt rev-parse --short HEAD)
+          TARGET="$(date -u +%Y/%Y-%m-%d-%H%M%S)-$COMMIT"
+          mkdir -p results-branch/$(dirname $TARGET)
+          cp -rv results results-branch/$TARGET
+
+          # Commit the new results.
+          cd results-branch
+          git config --local \
+            user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local \
+            user.name "github-actions[bot]"
+          git add .
+          git commit -m "Results for $COMMIT"
+
+          # Push the results. If the push fails, assume that it's because some
+          # other job happened to push in the meantime.
+          RETRY=0
+          while ! git push; do
+            if (( ++RETRY == 10 )); then
+              echo "Giving up after $RETRY failed attempts to push results" &>2
+              exit 1
+            fi
+            git pull --rebase
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.git*
 !.editorconfig
 /build
+/results

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ verilog/sv-tests/run.sh
   Contains useful scripts to update only the necessary submodules, among other things.
 - **verilog**: Tests for the Verilog frontend of CIRCT.
 
+The following temporary directories are created while running builds and tests:
+
+- **build**: Build artifacts such as compiled cores.
+- **results**: Test results that should be archived and tracked.
+  These can be statistics about failing tests, diagnostics, or performance numbers.
+  CI will push the contents of this directory to the `results` branch.
+
 ## Cores
 
 ### Snitch

--- a/verilog/sv-tests/stats.sh
+++ b/verilog/sv-tests/stats.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-set -e
-cd "$(dirname "${BASH_SOURCE[0]}")/../../ext/sv-tests"
-
-# This script produces a bunch of statistics in the `ext/sv-tests/out/logs`
+# This script produces a bunch of statistics in the `results/sv-tests`
 # directory. Run this after `run.sh`.
+set -e
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+mkdir -p results/sv-tests
 
 # Collect the runs that segfaulted.
-grep -rl "submit a bug report" out/logs \
-| sort -u > out/runs_segfault.txt
+grep -rl "submit a bug report" ext/sv-tests/out/logs \
+| sort -u > results/sv-tests/segfaults.txt
 
 # Collect the runs that had error or warning messages in tests that are not
 # expected to fail.
-grep -Erl " (error|warning): " out/logs \
+grep -Erl " (error|warning): " ext/sv-tests/out/logs \
 | xargs grep -L "should_fail: 1" \
-| sort -u > out/runs_diagnostics.txt
+| sort -u > results/sv-tests/diagnostics.txt
 
 # Create a ranking of the most common error messages.
-cat out/runs_diagnostics.txt \
+cat results/sv-tests/diagnostics.txt \
 | xargs grep -ho "error: .*" \
-| sort | uniq -c | sort -nr > out/errors.txt
+| sort | uniq -c | sort -nr > results/sv-tests/errors.txt


### PR DESCRIPTION
Make tests write their interesting statistics to the `results` directory and have CI push that directory to the `results` branch, with an appropriate timestamp attached. This will archive the run results and allow us to later analyze it as a time series.