### PR TITLE
Use dependabot to keep submodules up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,3 +202,19 @@ jobs:
           gh api "repos/llvm/circt/issues/${{ inputs.pr_number }}/comments" \
             -f body="$(cat summary.md)"
           echo "Posted comment on PR #${{ inputs.pr_number }}"
+
+  # Auto-merge Dependabot PRs after tests pass
+  auto-merge-dependabot:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    needs: run-tests
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Merge Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge "$PR_NUMBER" --squash --repo ${{ github.repository }}


### PR DESCRIPTION
Add a Dependabot config to create weekly submodule bump PRs. Also add a step to CI that automatically merges these PRs once the tests pass.