### PR TITLE
[CI] Speed up main fetch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           ref: ${{ steps.trigger.outputs.ref }}
           submodules: recursive
           path: circt
-          fetch-depth: 200
+          fetch-depth: 50
 
       # Fetch the *target* (upstream) main branch by URL so that `find-base.py`
       # can compute the merge-base of the current commit against the real
@@ -80,7 +80,7 @@ jobs:
       # same commit.
       - name: Fetch CIRCT target main branch
         run: |
-          git -C circt fetch --depth=200 \
+          git -C circt fetch --no-tags --no-recurse-submodules --depth=50 \
             https://github.com/llvm/circt.git \
             +refs/heads/main:refs/remotes/target/main
 


### PR DESCRIPTION
We recently ran into an issue where the CIRCT build now requires cmake version 3.28 or later to build. (Thanks @VecoMr for fixing that!) This newer version is likely part of a newer CIRCT image, which we can swap in instead of manually installing cmake.

Also reduce the fetch depth and avoid fetching tags and submodules when grabbing the target main branch. This used to take an excessive 10 min in CI.