### PR TITLE
[sv-tests] Fix false-positive errors from string literals in printed MLIR

### DIFF
--- a/verilog/sv-tests/stats.sh
+++ b/verilog/sv-tests/stats.sh
@@ -13,7 +13,7 @@ grep -rl "submit a bug report" ext/sv-tests/out/logs \
 # expected to fail. Exclude segfaulting tests since their error output is
 # non-deterministic (depends on thread scheduling during parallel pass
 # execution), which causes flaky error counts between runs.
-grep -Erl " (error|warning): " ext/sv-tests/out/logs \
+grep -Erl "^[^[:space:]].* (error|warning): " ext/sv-tests/out/logs \
 | xargs grep -L "should_fail: 1" \
 | sort -u \
 | comm -23 - results/sv-tests/segfaults.txt \
@@ -24,11 +24,12 @@ grep -Erl " (error|warning): " ext/sv-tests/out/logs \
 # counting as a unique error.
 {
   cat results/sv-tests/diagnostics.txt \
-  | xargs grep -ho "error: failed to legalize operation '[^']*'" || true
+  | xargs grep -ho "^[^[:space:]].*error: failed to legalize operation '[^']*'" || true
   cat results/sv-tests/diagnostics.txt \
-  | xargs grep -ho "error: .*" \
+  | xargs grep -ho "^[^[:space:]].*error: .*" \
   | grep -v "error: failed to legalize operation " || true
-} | sort | uniq -c | sort -nr > results/sv-tests/errors.txt
+} | sed -E 's/^.*error: /error: /' \
+  | sort | uniq -c | sort -nr > results/sv-tests/errors.txt
 
 # Collect all test log file paths.
 find ext/sv-tests/out/logs -name "*.log" -type f \
@@ -51,10 +52,16 @@ awk -F'\t' '
 ' <(
   {
     cat results/sv-tests/diagnostics.txt \
-    | xargs grep -Ho "error: failed to legalize operation '[^']*'" || true
+    | xargs grep -Ho "^[^[:space:]].*error: failed to legalize operation '[^']*'" || true
     cat results/sv-tests/diagnostics.txt \
-    | xargs grep -Ho "error: .*" \
+    | xargs grep -Ho "^[^[:space:]].*error: .*" \
     | grep -v "error: failed to legalize operation " || true
-  } | awk '{n=index($0, ":"); print substr($0, n+1) "\t" substr($0, 1, n-1)}' \
+  } | awk '{
+      n=index($0, ":")
+      file = substr($0, 1, n-1)
+      rest = substr($0, n+1)
+      m = index(rest, "error: ")
+      print substr(rest, m) "\t" file
+    }' \
     | sort -u
 ) results/sv-tests/errors.txt > results/sv-tests/errors-source.txt


### PR DESCRIPTION
`stats.sh` scans logs for lines containing "error:" or "warning:" to build `diagnostics.txt` and rank the most common errors in `errors.txt`. This matches anywhere in the log, including inside the textual IR that `circt-verilog` prints for successfully compiled modules.

For example in [CIRCT PR](https://github.com/llvm/circt/pull/10789) generates MLIR that includes `%1 = sim.fmt.literal "\22): error: address out of range or malformed input\0A"` and `%4 = sim.fmt.literal "\22): error: cannot open file\0A"` but `circt-tests` flagged these as false-positive errors.

Real diagnostics from `circt-verilog` are always printed flush-left as `file:line:col: error: ...`, while the printed MLIR is always indented, so the fix restricts error/warning detection to non-indented lines to exclude these string literals without missing any real diagnostic.
